### PR TITLE
feature: support systemd sd_notify protocol

### DIFF
--- a/src/otaclient_iot_logging_server/_sd_notify.py
+++ b/src/otaclient_iot_logging_server/_sd_notify.py
@@ -30,6 +30,10 @@ def get_notify_socket() -> str | None:
     return os.getenv(SD_NOTIFY_SOCKET_ENV)
 
 
+def sd_notify_enabled() -> bool:
+    return bool(os.getenv(SD_NOTIFY_SOCKET_ENV))
+
+
 async def sd_notify(msg: str) -> bool | None:
     if not (notify_socket := get_notify_socket()):
         return

--- a/src/otaclient_iot_logging_server/_sd_notify.py
+++ b/src/otaclient_iot_logging_server/_sd_notify.py
@@ -1,0 +1,51 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A simple implementation of systemd sd_nofity protocol."""
+
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+
+logger = logging.getLogger(__name__)
+
+READY_MSG = "READY=1"
+SD_NOTIFY_SOCKET_ENV = "NOTIFY_SOCKET"
+
+
+def get_notify_socket() -> str | None:
+    return os.getenv(SD_NOTIFY_SOCKET_ENV)
+
+
+def send_msg() -> bool | None:
+    if not (notify_socket := get_notify_socket()):
+        return
+    logger.info("otaclient-logger service is configured to send ready msg to systemd")
+
+    socket_link = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        socket_link.connect(notify_socket)
+    except Exception as e:
+        logger.warning(f"failed to connect to {notify_socket=}: {e!r}")
+        return False
+
+    try:
+        socket_link.sendall(READY_MSG.encode())
+        logger.info("sent ready message to systemd")
+        return True
+    except Exception as e:
+        logger.warning(f"failed to send ready message to notify socket: {e!r}")
+        return False

--- a/src/otaclient_iot_logging_server/_sd_notify.py
+++ b/src/otaclient_iot_logging_server/_sd_notify.py
@@ -30,10 +30,13 @@ def get_notify_socket() -> str | None:
     return os.getenv(SD_NOTIFY_SOCKET_ENV)
 
 
-def send_msg() -> bool | None:
+def sd_notify_enabled() -> bool:
+    return bool(os.getenv(SD_NOTIFY_SOCKET_ENV))
+
+
+def sd_notify(msg: str) -> bool | None:
     if not (notify_socket := get_notify_socket()):
         return
-    logger.info("otaclient-logger service is configured to send ready msg to systemd")
 
     socket_link = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     try:
@@ -43,7 +46,7 @@ def send_msg() -> bool | None:
         return False
 
     try:
-        socket_link.sendall(READY_MSG.encode())
+        socket_link.sendall(msg.encode())
         logger.info("sent ready message to systemd")
         return True
     except Exception as e:

--- a/src/otaclient_iot_logging_server/_sd_notify.py
+++ b/src/otaclient_iot_logging_server/_sd_notify.py
@@ -16,9 +16,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
+import socket
 
 logger = logging.getLogger(__name__)
 
@@ -30,29 +30,24 @@ def get_notify_socket() -> str | None:
     return os.getenv(SD_NOTIFY_SOCKET_ENV)
 
 
-def sd_notify_enabled() -> bool:
-    return bool(os.getenv(SD_NOTIFY_SOCKET_ENV))
-
-
-async def sd_notify(msg: str) -> bool | None:
+def send_msg() -> bool | None:
     if not (notify_socket := get_notify_socket()):
         return
     logger.info("otaclient-logger service is configured to send ready msg to systemd")
 
+    socket_link = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     try:
-        _, writer = await asyncio.open_unix_connection(notify_socket)
+        socket_link.connect(notify_socket)
     except Exception as e:
         logger.warning(f"failed to connect to {notify_socket=}: {e!r}")
         return False
 
     try:
-        writer.write(msg.encode())
-        await writer.drain()
+        socket_link.sendall(READY_MSG.encode())
         logger.info("sent ready message to systemd")
         return True
     except Exception as e:
         logger.warning(f"failed to send ready message to notify socket: {e!r}")
         return False
     finally:
-        writer.close()
-        await writer.wait_closed()
+        socket_link.close()

--- a/src/otaclient_iot_logging_server/_sd_notify.py
+++ b/src/otaclient_iot_logging_server/_sd_notify.py
@@ -30,7 +30,7 @@ def get_notify_socket() -> str | None:
     return os.getenv(SD_NOTIFY_SOCKET_ENV)
 
 
-async def send_msg() -> bool | None:
+async def sd_notify(msg: str) -> bool | None:
     if not (notify_socket := get_notify_socket()):
         return
     logger.info("otaclient-logger service is configured to send ready msg to systemd")
@@ -42,7 +42,7 @@ async def send_msg() -> bool | None:
         return False
 
     try:
-        writer.write(READY_MSG.encode())
+        writer.write(msg.encode())
         await writer.drain()
         logger.info("sent ready message to systemd")
         return True

--- a/tests/test__sd_notify.py
+++ b/tests/test__sd_notify.py
@@ -64,6 +64,20 @@ def test_get_notify_socket(input, expected, monkeypatch):
     assert _sd_notify.get_notify_socket() == expected
 
 
+@pytest.mark.parametrize(
+    "input, expected",
+    (
+        ("/a/normal/socket/path", True),
+        ("@a/abstract/unix/socket", True),
+        (None, False),
+    ),
+)
+def test_sd_notify_enabled(input, expected, monkeypatch):
+    if input:
+        monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, input)
+    assert _sd_notify.sd_notify_enabled() == expected
+
+
 def test_sd_notify(socket_conn_mock, socket_object_mock, monkeypatch):
     NOTIFY_SOCKET = "any_non_empty_value"
     monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, NOTIFY_SOCKET)

--- a/tests/test__sd_notify.py
+++ b/tests/test__sd_notify.py
@@ -1,0 +1,80 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+import pytest_mock
+
+from otaclient_iot_logging_server import _sd_notify
+
+SD_NOTIFY_MODULE = _sd_notify.__name__
+
+
+@pytest.fixture
+def socket_object_mock(mocker: pytest_mock.MockerFixture):
+    return mocker.MagicMock(spec=socket.socket)
+
+
+@pytest.fixture
+def socket_conn_mock(mocker: pytest_mock.MockerFixture, socket_object_mock):
+    class DummySocketObject:
+
+        _mock: Any = socket_object_mock
+
+        def __new__(cls, _family, _type, *args):
+            cls._family = _family
+            cls._type = _type
+            return object.__new__(cls)
+
+        def __enter__(self):
+            return self._mock
+
+        def __exit__(self, *_):
+            return
+
+    mocker.patch(f"{SD_NOTIFY_MODULE}.socket.socket", DummySocketObject)
+    yield DummySocketObject
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    (
+        (socket_path := "/a/normal/socket/path", socket_path),
+        ("@a/abstract/unix/socket", "\0a/abstract/unix/socket"),
+    ),
+)
+def test_get_notify_socket(input, expected, monkeypatch):
+    monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, input)
+    assert _sd_notify.get_notify_socket() == expected
+
+
+def test_sd_notify(socket_conn_mock, socket_object_mock, monkeypatch):
+    NOTIFY_SOCKET = "any_non_empty_value"
+    monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, NOTIFY_SOCKET)
+
+    # ------ execute ------ #
+    _sd_notify.sd_notify(_sd_notify.READY_MSG)
+
+    # ------ check result ------ #
+    dummy_socket_class = socket_conn_mock
+    assert dummy_socket_class._family == socket.AF_UNIX
+    assert dummy_socket_class._type == socket.SOCK_DGRAM
+
+    socket_object_mock.connect.assert_called_once_with(NOTIFY_SOCKET)
+    socket_object_mock.sendall.assert_called_once_with(_sd_notify.READY_MSG.encode())


### PR DESCRIPTION
## Introduction

This PR adds support for system sd_notify protocol, supporting otaclient-logger service running with `Type=notify`.

## Motivation

By default, systemd service is labelled as active running as soon as the main process forked off. 
Our new otaclient-logger is feature-rich than the original old one from otaclient, however 
it comes with a drawback which it takes slightly more time to start up. 
It results in an edge condition that, even we set the startup order to let otaclient-logger starts before otaclient, otaclient might still start faster than otaclient-logger service itself is ready(there is a small time gap between the service is forked off and the service is ready), resulting in some of the logs being dropped. 