### PR TITLE
ci: use ruff as linter to replace isort and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-extend-ignore = E266, E501, E203
-max-line-length = 88
-max-complexity = 16

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.2
     hooks:
-      - id: python-check-mock-methods
-      - id: python-use-type-annotations
+      - id: ruff
+        args: [--fix]
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.4.2
@@ -19,18 +19,6 @@ repos:
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear==24.2.6
-          - flake8-comprehensions
-          - flake8-simplify
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "2.1.3"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,33 @@ sources = [
   "src",
 ]
 
+[tool.ruff]
+target-version = "py311"
+# NOTE: not include tests and tools for now
+include = [
+  "pyproject.toml",
+  "src/**/*.py",
+  "tests/**/*.py",
+]
+
+lint.select = [
+  "A",   # flake8-builtins
+  "B",   # flake8-bugbear
+  "E4",
+  "E7",
+  "E9",
+  "F",   # pyflakes
+  "I",   # isort
+  "ICN", # flake8-import-conventions
+  "Q",   # flake8-quotes
+]
+lint.ignore = [
+  "E203", # (white space before ':'): this error conflicts with black linting
+  "E266", # (too many leading '#'): sometimes we use multiple # for separting sections
+  "E701", # (multiple statements on one line)
+  "S101", # (use of assert): mostly we use assert for typing
+]
+
 [tool.pytest.ini_options]
 env = [
   "AWS_PROFILE_INFO=tests/data/aws_profile_info.yaml",
@@ -111,31 +138,3 @@ exclude_also = [
 ]
 show_missing = true
 skip_empty = true
-
-[tool.ruff]
-target-version = "py311"
-# NOTE: not include tests and tools for now
-include = [
-  "tests/**/*.py",
-  "src/**/*.py",
-  "pyproject.toml",
-]
-
-[tool.ruff.lint]
-select = [
-  "E4",
-  "E7",
-  "E9",
-  "F",   # pyflakes
-  "Q",   # flake8-quotes
-  "I",   # isort
-  "B",   # flake8-bugbear
-  "A",   # flake8-builtins
-  "ICN", # flake8-import-conventions
-]
-ignore = [
-  "E266", # (too many leading '#'): sometimes we use multiple # for separting sections
-  "E203", # (white space before ':'): this error conflicts with black linting
-  "E701", # (multiple statements on one line)
-  "S101", # (use of assert): mostly we use assert for typing
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,19 +76,6 @@ sources = [
   "src",
 ]
 
-[tool.black]
-line-length = 88
-
-[tool.isort]
-atomic = true
-profile = "black"
-line_length = 88
-lines_before_imports = 2
-skip_gitignore = true
-known_first_party = [
-  "otaclient_iot_logging_server",
-]
-
 [tool.pytest.ini_options]
 env = [
   "AWS_PROFILE_INFO=tests/data/aws_profile_info.yaml",
@@ -124,3 +111,31 @@ exclude_also = [
 ]
 show_missing = true
 skip_empty = true
+
+[tool.ruff]
+target-version = "py311"
+# NOTE: not include tests and tools for now
+include = [
+  "tests/**/*.py",
+  "src/**/*.py",
+  "pyproject.toml",
+]
+
+[tool.ruff.lint]
+select = [
+  "E4",
+  "E7",
+  "E9",
+  "F",   # pyflakes
+  "Q",   # flake8-quotes
+  "I",   # isort
+  "B",   # flake8-bugbear
+  "A",   # flake8-builtins
+  "ICN", # flake8-import-conventions
+]
+ignore = [
+  "E266", # (too many leading '#'): sometimes we use multiple # for separting sections
+  "E203", # (white space before ':'): this error conflicts with black linting
+  "E701", # (multiple statements on one line)
+  "S101", # (use of assert): mostly we use assert for typing
+]

--- a/src/otaclient_iot_logging_server/__main__.py
+++ b/src/otaclient_iot_logging_server/__main__.py
@@ -32,7 +32,7 @@ def main() -> None:
     # ------ configure local logging ------ #
     root_logger = config_logging(
         queue,
-        format=server_cfg.SERVER_LOGGING_LOG_FORMAT,
+        log_format=server_cfg.SERVER_LOGGING_LOG_FORMAT,
         level=server_cfg.SERVER_LOGGING_LEVEL,
         enable_server_log=server_cfg.UPLOAD_LOGGING_SERVER_LOGS,
         server_logstream_suffix=server_cfg.SERVER_LOGSTREAM_SUFFIX,

--- a/src/otaclient_iot_logging_server/_log_setting.py
+++ b/src/otaclient_iot_logging_server/_log_setting.py
@@ -53,14 +53,14 @@ class _LogTeeHandler(logging.Handler):
 def config_logging(
     queue: Queue[tuple[str, LogMessage]],
     *,
-    format: str,
+    log_format: str,
     level: str,
     enable_server_log: bool,
     server_logstream_suffix: str,
 ):
     # NOTE: for the root logger, set to CRITICAL to filter away logs from other
     #       external modules unless reached CRITICAL level.
-    logging.basicConfig(level=logging.CRITICAL, format=format, force=True)
+    logging.basicConfig(level=logging.CRITICAL, format=log_format, force=True)
     # NOTE: set the <loglevel> to the package root logger
     root_logger = logging.getLogger(root_package_name)
     root_logger.setLevel(level)

--- a/src/otaclient_iot_logging_server/aws_iot_logger.py
+++ b/src/otaclient_iot_logging_server/aws_iot_logger.py
@@ -92,7 +92,7 @@ class AWSIoTLogger:
                 logger.error(
                     (f"failed to create mtls connection to remote: {e.__cause__}")
                 )
-                raise e.__cause__
+                raise e.__cause__ from None
             logger.error(f"failed to create {log_group_name=}: {e!r}")
             raise
         except Exception as e:
@@ -118,7 +118,7 @@ class AWSIoTLogger:
                 logger.error(
                     (f"failed to create mtls connection to remote: {e.__cause__}")
                 )
-                raise e.__cause__
+                raise e.__cause__ from None
             logger.error(f"failed to create {log_stream_name=}@{log_group_name}: {e!r}")
             raise
         except Exception as e:

--- a/tests/test__sd_notify.py
+++ b/tests/test__sd_notify.py
@@ -53,28 +53,28 @@ def socket_conn_mock(mocker: pytest_mock.MockerFixture, socket_object_mock):
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "_input, expected",
     (
         (socket_path := "/a/normal/socket/path", socket_path),
         ("@a/abstract/unix/socket", "\0a/abstract/unix/socket"),
     ),
 )
-def test_get_notify_socket(input, expected, monkeypatch):
-    monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, input)
+def test_get_notify_socket(_input, expected, monkeypatch):
+    monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, _input)
     assert _sd_notify.get_notify_socket() == expected
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "_input, expected",
     (
         ("/a/normal/socket/path", True),
         ("@a/abstract/unix/socket", True),
         (None, False),
     ),
 )
-def test_sd_notify_enabled(input, expected, monkeypatch):
-    if input:
-        monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, input)
+def test_sd_notify_enabled(_input, expected, monkeypatch):
+    if _input:
+        monkeypatch.setenv(_sd_notify.SD_NOTIFY_SOCKET_ENV, _input)
     assert _sd_notify.sd_notify_enabled() == expected
 
 


### PR DESCRIPTION
Also see https://github.com/tier4/ota-client/pull/381.