### PR TITLE
ci: fix test breaks and cleanup unneeded python_lint_check action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,29 +93,3 @@ jobs:
 
       - name: Execute pytest
         run: pytest
-
-  python_lint_check:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 3
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-    steps:
-      - name: Checkout commit
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install check dependencies
-        run: |
-          python -m pip install -q -U pip
-          pip install -q .[dev]
-
-      - name: Check code linting
-        run: |
-          black --check src
-          flake8 src

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -74,7 +74,7 @@ def test_main(
     # ------ check result ------ #
     _logger_mock.assert_called_once_with(
         mocker.ANY,
-        format=_in_server_cfg.SERVER_LOGGING_LOG_FORMAT,
+        log_format=_in_server_cfg.SERVER_LOGGING_LOG_FORMAT,
         level=_in_server_cfg.SERVER_LOGGING_LEVEL,
         enable_server_log=_in_server_cfg.UPLOAD_LOGGING_SERVER_LOGS,
         server_logstream_suffix=_in_server_cfg.SERVER_LOGSTREAM_SUFFIX,


### PR DESCRIPTION
This PR fixes test breaking on #9, and remove the python_lint_check action as not needed.