### PR TITLE
feat: define protobuf interface to communicate with ota-client

### DIFF
--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+dist/
+build/

--- a/proto/README.md
+++ b/proto/README.md
@@ -7,20 +7,20 @@ You can use `hatch` to simply build the OTA Client Logging service API python pa
 
 1. setup a venv and install hatch:
 
-```shell
-python3 -m venv .venv
-# enable the venv
-. .venv/bin/activate
-python3 -m pip install -U pip
-python3 -m pip install hatch
-```
+    ```shell
+    python3 -m venv .venv
+    # enable the venv
+    . .venv/bin/activate
+    python3 -m pip install -U pip
+    python3 -m pip install hatch
+    ```
 
 2. build the wheel package with hatch
 
-```shell
-# enable the venv
-. .venv/bin/activate
-hatch build -t wheel
-```
+    ```shell
+    # enable the venv
+    . .venv/bin/activate
+    hatch build -t wheel
+    ```
 
 3. the built package will be placed under `./dist` folder

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,26 @@
+# OTA Logging Server Service API proto
+
+This folder includes the OTA Client Logging service API proto file, and is also a configured python package.
+You can use `hatch` to simply build the OTA Client Logging service API python package for building grpc server or client.
+
+## How to build
+
+1. setup a venv and install hatch:
+
+```shell
+python3 -m venv .venv
+# enable the venv
+. .venv/bin/activate
+python3 -m pip install -U pip
+python3 -m pip install hatch
+```
+
+2. build the wheel package with hatch
+
+```shell
+# enable the venv
+. .venv/bin/activate
+hatch build -t wheel
+```
+
+3. the built package will be placed under `./dist` folder

--- a/proto/hatch_build.py
+++ b/proto/hatch_build.py
@@ -1,0 +1,102 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dynamically generate protobuf python code."""
+
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+OUTPUT_BASE = "src"
+
+
+def _protoc_compile(
+    proto_file: str,
+    output_base: str,
+    output_package: str,
+    *,
+    extra_imports: list[str] | None,
+    work_dir: str | Path,
+):
+    # copy the proto_file to the output_dir to retain the proper package import layout
+    output_package_dir = Path(output_base) / output_package
+    shutil.copy(proto_file, output_package_dir)
+    _proto_file = output_package_dir / os.path.basename(proto_file)
+
+    # fmt: off
+    cmd = [
+        sys.executable, "-m", "grpc_tools.protoc",
+        f"--python_out={output_base}",
+        f"--pyi_out={output_base}",
+        f"--grpc_python_out={output_base}",
+    ]
+    # fmt: on
+    if isinstance(extra_imports, list):
+        for _import in extra_imports:
+            cmd.append(f"-I{_import}")
+    # also place the output_base as import path
+    cmd.append(f"-I{output_base}")
+
+    cmd.append(str(_proto_file))
+    print(f"call protoc with: {' '.join(cmd)}")
+    subprocess.check_call(cmd, cwd=work_dir)
+
+
+class CustomBuildHook(BuildHookInterface):
+    """
+    Configs:
+        api_version: the API version of otaclient-iot-logging-server service API.
+    """
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        for config in self.config["proto_builds"]:
+            # ------ parse config ------ #
+            proto_file = config["proto_file"]
+            print(f"build protoc python code for {proto_file} ...")
+
+            output_package = config["output_package"]
+            extra_imports = config.get("extra_imports", [])
+
+            # ------ load consts ------ #
+            output_base = OUTPUT_BASE
+
+            # ------ validate config ------ #
+            if not isinstance(extra_imports, list):
+                raise ValueError(
+                    f"expect extra_imports to be a list, get {type(extra_imports)}"
+                )
+
+            if not os.path.exists(proto_file):
+                raise FileNotFoundError(f"{proto_file=} not found, abort")
+
+            # let the folder where proto file exists become the work_dir
+            work_dir = os.path.dirname(proto_file)
+            if not work_dir:
+                work_dir = "."
+
+            # ------ compile proto file ------ #
+            _protoc_compile(
+                proto_file,
+                extra_imports=extra_imports,
+                output_base=output_base,
+                output_package=output_package,
+                work_dir=work_dir,
+            )

--- a/proto/otaclient_iot_logging_server_v1.proto
+++ b/proto/otaclient_iot_logging_server_v1.proto
@@ -26,16 +26,17 @@ enum LogType {
   METRICS = 1;
 }
 enum LogLevel {
-  TRACE = 0;
-  DEBUG = 1;
-  INFO = 2;
-  WARN = 3;
-  ERROR = 4;
-  FATAL = 5;
+  UNSPECIFIC = 0;
+  TRACE = 1;
+  DEBUG = 2;
+  INFO = 3;
+  WARN = 4;
+  ERROR = 5;
+  FATAL = 6;
 }
 enum ErrorCode {
   OK = 0;
-  UNKNOWN = 1;
+  FAILED = 1;
 }
 message PutLogRequest {
   LogType type = 1;

--- a/proto/otaclient_iot_logging_server_v1.proto
+++ b/proto/otaclient_iot_logging_server_v1.proto
@@ -1,0 +1,50 @@
+// Copyright 2022 TIER IV, INC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+service OtaClientLoggingService {
+  /*
+   * `PutLog` service requests OTA Client logging service to put log.
+   */
+  rpc PutLog(PutLogRequest) returns (PutLogResponse) {}
+}
+
+enum LogType {
+  LOG = 0;
+  METRICS = 1;
+}
+enum LogLevel {
+  TRACE = 0;
+  DEBUG = 1;
+  INFO = 2;
+  WARN = 3;
+  ERROR = 4;
+  FATAL = 5;
+}
+enum ErrorCode {
+  OK = 0;
+  UNKNOWN = 1;
+}
+message PutLogRequest {
+  LogType type = 1;
+  uint64 timestamp = 2;
+  LogLevel level = 3;
+  string data = 4;
+}
+
+message PutLogResponse {
+  ErrorCode code = 1;
+  string message = 2;
+}

--- a/proto/pyproject.toml
+++ b/proto/pyproject.toml
@@ -1,0 +1,83 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = [
+  "grpcio-tools<1.58,>=1.57",
+  "hatch-vcs",
+  "hatchling>=1.20",
+]
+
+[project]
+name = "otaclient-iot-logging-server-pb2"
+version = "1.0.0"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: Unix",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+urls.Source = "https://github.com/tier4/otaclient-iot-logging-server/proto"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/otaclient_iot_logging_server_pb2/_version.py"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "whl",
+]
+
+[tool.hatch.build.targets.wheel]
+exclude = [
+  "**/.gitignore",
+  "**/*README.md",
+  "whl",
+]
+only-include = [
+  "src",
+]
+sources = [
+  "src",
+]
+
+[tool.hatch.build.hooks.custom]
+proto_builds = [
+  { proto_file = "otaclient_iot_logging_server_v1.proto", output_package = "otaclient_iot_logging_server_pb2/v1", api_version = "1.0.0" },
+]
+
+[tool.black]
+line-length = 88
+target-version = [
+  'py38',
+]
+extend-exclude = '''(
+  ^.*(_pb2.pyi?|_pb2_grpc.pyi?)$
+)'''
+
+[tool.isort]
+profile = "black"
+extend_skip_glob = [
+  "*_pb2.py*",
+  "_pb2_grpc.py*",
+]
+
+[tool.pyright]
+exclude = [
+  "**/__pycache__",
+  "**/.venv",
+]
+ignore = [
+  "**/*_pb2.py*",
+  "**/*_pb2_grpc.py*",
+]
+pythonVersion = "3.8"

--- a/proto/pyproject.toml
+++ b/proto/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
-  "grpcio-tools<1.58,>=1.57",
+  "grpcio-tools>=1.57,<1.58",
   "hatch-vcs",
   "hatchling>=1.20",
 ]
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 urls.Source = "https://github.com/tier4/otaclient-iot-logging-server/proto"
 

--- a/proto/src/otaclient_iot_logging_server_pb2/.gitignore
+++ b/proto/src/otaclient_iot_logging_server_pb2/.gitignore
@@ -1,0 +1,2 @@
+# generated version file by build
+_version.py

--- a/proto/src/otaclient_iot_logging_server_pb2/__init__.py
+++ b/proto/src/otaclient_iot_logging_server_pb2/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from otaclient_iot_logging_server_pb2._version import version, version_tuple
+
+__version__ = version
+__version_tuple__ = version_tuple

--- a/proto/src/otaclient_iot_logging_server_pb2/v1/.gitignore
+++ b/proto/src/otaclient_iot_logging_server_pb2/v1/.gitignore
@@ -1,0 +1,4 @@
+!__init__.py
+*.py
+*.pyi
+*.proto

--- a/proto/src/otaclient_iot_logging_server_pb2/v1/__init__.py
+++ b/proto/src/otaclient_iot_logging_server_pb2/v1/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 TIER IV, INC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = version = "1.0.0"
+__version_tuple__ = version_tuple = (1, 0, 0)
+
+__all__ = ["version", "__version__", "version_tuple", "__version_tuple__"]


### PR DESCRIPTION
### Why
https://tier4.atlassian.net/browse/RT4-13461
To retrieve the metrics, we plan to refactor the interface between ota-client and otaclient-iot-logging-server from REST to gRPC based on [this design](https://tier4.atlassian.net/wiki/spaces/OTA/pages/3481894920/OTA+Metrics).

### What
This PR just defines the protobuf interface to communicate.
Core and test part will be implemented in the later PR.

### Tests
Verified that `hatch build -t wheel` creates the expected `.whl`.