### PR TITLE
fix: iot-logging : Update grpcio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "awsiot-credentialhelper>=0.6,<0.7",
   "boto3>=1.34.35,<1.35",
   "botocore==1.34.35,<1.35",
-  "grpcio==1.70.0",
+  "grpcio==1.70",
   "protobuf>=4.21.12,<5.29",
   "pydantic>=2.6,<3",
   "pydantic-settings>=2.2.1,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "awsiot-credentialhelper>=0.6,<0.7",
   "boto3>=1.34.35,<1.35",
   "botocore==1.34.35,<1.35",
-  "grpcio>=1.53.2,<1.69",
+  "grpcio==1.70.0",
   "protobuf>=4.21.12,<5.29",
   "pydantic>=2.6,<3",
   "pydantic-settings>=2.2.1,<3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.10.11
 awsiot-credentialhelper>=0.6,<0.7
 boto3>=1.34.35,<1.35
 botocore==1.34.35,<1.35
-grpcio==1.70.0
+grpcio==1.70
 protobuf>=4.21.12,<5.29
 pydantic>=2.6,<3
 pydantic-settings>=2.2.1,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.10.11
 awsiot-credentialhelper>=0.6,<0.7
 boto3>=1.34.35,<1.35
 botocore==1.34.35,<1.35
-grpcio>=1.53.2,<1.69
+grpcio==1.70.0
 protobuf>=4.21.12,<5.29
 pydantic>=2.6,<3
 pydantic-settings>=2.2.1,<3


### PR DESCRIPTION
### Related JIRA
https://tier4.atlassian.net/browse/RT4-15433

### About This Fix
As being adviced here
https://security.snyk.io/vuln/SNYK-PYTHON-GRPCIO-9486468
![image](https://github.com/user-attachments/assets/9fb09ca9-e6b3-42cd-9409-8b7351528beb)


Change grpcio to  version listed here
https://pypi.org/project/grpcio/#history

### Note :
lastest version is : 1.71.0
But it is not supported for ubuntu 18.04 and 20.04.
So we use 1.70.0
