### PR TITLE
chore: allow manual trigger of release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,8 @@ name: build wheel for release
 on:
   release:
     types: [published]
+  # allow the test CI to be manually triggerred
+  workflow_dispatch:
 
 permissions:
   contents: write # upload artifacts requires this permission


### PR DESCRIPTION
### Why
To test `release.yaml` manually on Github Actions.

### What
Add `workflow_dispatch` in release.yaml