### PR TITLE
fix: support that timestamp is zero for gRPC communication

### DIFF
--- a/src/otaclient_iot_logging_server/servicer.py
+++ b/src/otaclient_iot_logging_server/servicer.py
@@ -89,7 +89,7 @@ class OTAClientIoTLoggingServerServicer:
             return ErrorCode.NOT_ALLOWED_ECU_ID
 
         _logging_group_type = self.convert_from_log_type_to_log_group_type(log_type)
-        if timestamp is None:
+        if timestamp is None or timestamp == 0:
             timestamp = int(time.time()) * 1000  # milliseconds
         _logging_msg = LogMessage(
             timestamp=timestamp,

--- a/tools/api_health_check.py
+++ b/tools/api_health_check.py
@@ -11,7 +11,7 @@ from otaclient_iot_logging_server.v1 import (
 async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
     """
     Simple gRPC client for health check
-
+    
     Args:
         server_address: Server address to connect to (e.g., "127.0.0.1:8084")
     """
@@ -19,19 +19,19 @@ async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
     async with grpc.aio.insecure_channel(server_address) as channel:
         # Create stub
         stub = pb2_grpc.OTAClientIoTLoggingServiceStub(channel)
-
+        
         try:
             # Create HealthCheckRequest
             request = pb2.HealthCheckRequest()
             print(f"Sending health check request to {server_address}...")
-
+            
             # Call Check API
             response = await stub.Check(request)
-
+            
             # Display response
             print(f"Health check response: {response}")
             print(f"Status: {response.status}")
-
+            
         except grpc.RpcError as e:
             print(f"RPC error: {e.code()}: {e.details()}")
         except Exception as e:
@@ -40,9 +40,9 @@ async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
 
 if __name__ == "__main__":
     import sys
-
+    
     # Get server address from command line arguments (default: 127.0.0.1:8084)
     server_address = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:8084"
-
+    
     # Run async function
     asyncio.run(run_health_check(server_address))

--- a/tools/api_health_check.py
+++ b/tools/api_health_check.py
@@ -1,0 +1,48 @@
+import asyncio
+
+import grpc
+
+from otaclient_iot_logging_server.v1 import otaclient_iot_logging_server_v1_pb2 as pb2
+from otaclient_iot_logging_server.v1 import (
+    otaclient_iot_logging_server_v1_pb2_grpc as pb2_grpc,
+)
+
+
+async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
+    """
+    Simple gRPC client for health check
+    
+    Args:
+        server_address: Server address to connect to (e.g., "127.0.0.1:8084")
+    """
+    # Create async channel to server
+    async with grpc.aio.insecure_channel(server_address) as channel:
+        # Create stub
+        stub = pb2_grpc.OTAClientIoTLoggingServiceStub(channel)
+        
+        try:
+            # Create HealthCheckRequest
+            request = pb2.HealthCheckRequest()
+            print(f"Sending health check request to {server_address}...")
+            
+            # Call Check API
+            response = await stub.Check(request)
+            
+            # Display response
+            print(f"Health check response: {response}")
+            print(f"Status: {response.status}")
+            
+        except grpc.RpcError as e:
+            print(f"RPC error: {e.code()}: {e.details()}")
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    import sys
+    
+    # Get server address from command line arguments (default: 127.0.0.1:8084)
+    server_address = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:8084"
+    
+    # Run async function
+    asyncio.run(run_health_check(server_address))

--- a/tools/api_health_check.py
+++ b/tools/api_health_check.py
@@ -11,7 +11,7 @@ from otaclient_iot_logging_server.v1 import (
 async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
     """
     Simple gRPC client for health check
-    
+
     Args:
         server_address: Server address to connect to (e.g., "127.0.0.1:8084")
     """
@@ -19,19 +19,19 @@ async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
     async with grpc.aio.insecure_channel(server_address) as channel:
         # Create stub
         stub = pb2_grpc.OTAClientIoTLoggingServiceStub(channel)
-        
+
         try:
             # Create HealthCheckRequest
             request = pb2.HealthCheckRequest()
             print(f"Sending health check request to {server_address}...")
-            
+
             # Call Check API
             response = await stub.Check(request)
-            
+
             # Display response
             print(f"Health check response: {response}")
             print(f"Status: {response.status}")
-            
+
         except grpc.RpcError as e:
             print(f"RPC error: {e.code()}: {e.details()}")
         except Exception as e:
@@ -40,9 +40,9 @@ async def run_health_check(server_address: str = "127.0.0.1:8084") -> None:
 
 if __name__ == "__main__":
     import sys
-    
+
     # Get server address from command line arguments (default: 127.0.0.1:8084)
     server_address = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:8084"
-    
+
     # Run async function
     asyncio.run(run_health_check(server_address))

--- a/tools/api_put_log.py
+++ b/tools/api_put_log.py
@@ -1,0 +1,64 @@
+import asyncio
+import sys
+
+import grpc
+
+from otaclient_iot_logging_server.v1 import otaclient_iot_logging_server_v1_pb2 as pb2
+from otaclient_iot_logging_server.v1 import (
+    otaclient_iot_logging_server_v1_pb2_grpc as pb2_grpc,
+)
+
+
+async def run_put_log(
+    log_message: str,
+    server_address: str = "127.0.0.1:8084"
+) -> None:
+    """
+    Simple gRPC client for PutLog API
+    
+    Args:
+        log_message: The message to be logged
+        log_level: Log level (e.g., "INFO", "WARN", "ERROR")
+        server_address: Server address to connect to (e.g., "127.0.0.1:8084")
+    """
+    # Create async channel to server
+    async with grpc.aio.insecure_channel(server_address) as channel:
+        # Create stub
+        stub = pb2_grpc.OTAClientIoTLoggingServiceStub(channel)
+        
+        try:
+            # Create PutLogRequest directly
+            # Note: PutLogRequest structure depends on how it's defined in your .proto file
+            # This assumes the PutLogRequest has message, level, and timestamp fields
+            request = pb2.PutLogRequest(
+                ecu_id="autoware",
+                log_type=pb2.LogType.LOG,
+                message=log_message,
+            )
+            
+            print(f"Sending log entry to {server_address}:")
+            print(f"  Message: {log_message}")
+            
+            # Call PutLog API
+            response = await stub.PutLog(request)
+            
+            # Display response
+            print(f"PutLog response: {response}")
+            
+        except grpc.RpcError as e:
+            print(f"RPC error: {e.code()}: {e.details()}")
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    # Parse command line arguments
+    if len(sys.argv) < 2:
+        print("Usage: python api_put_log.py 'log message' [LOG_LEVEL] [server_address]")
+        sys.exit(1)
+    
+    log_message = sys.argv[1]
+    server_address = sys.argv[2] if len(sys.argv) > 2 else "127.0.0.1:8084"
+    
+    # Run async function
+    asyncio.run(run_put_log(log_message, server_address))

--- a/tools/api_put_log.py
+++ b/tools/api_put_log.py
@@ -15,7 +15,6 @@ async def run_put_log(log_message: str, server_address: str = "127.0.0.1:8084") 
 
     Args:
         log_message: The message to be logged
-        log_level: Log level (e.g., "INFO", "WARN", "ERROR")
         server_address: Server address to connect to (e.g., "127.0.0.1:8084")
     """
     # Create async channel to server
@@ -51,7 +50,7 @@ async def run_put_log(log_message: str, server_address: str = "127.0.0.1:8084") 
 if __name__ == "__main__":
     # Parse command line arguments
     if len(sys.argv) < 2:
-        print("Usage: python api_put_log.py 'log message' [LOG_LEVEL] [server_address]")
+        print("Usage: python api_put_log.py 'log message' [server_address]")
         sys.exit(1)
 
     log_message = sys.argv[1]

--- a/tools/api_put_log.py
+++ b/tools/api_put_log.py
@@ -9,13 +9,10 @@ from otaclient_iot_logging_server.v1 import (
 )
 
 
-async def run_put_log(
-    log_message: str,
-    server_address: str = "127.0.0.1:8084"
-) -> None:
+async def run_put_log(log_message: str, server_address: str = "127.0.0.1:8084") -> None:
     """
     Simple gRPC client for PutLog API
-    
+
     Args:
         log_message: The message to be logged
         log_level: Log level (e.g., "INFO", "WARN", "ERROR")
@@ -25,7 +22,7 @@ async def run_put_log(
     async with grpc.aio.insecure_channel(server_address) as channel:
         # Create stub
         stub = pb2_grpc.OTAClientIoTLoggingServiceStub(channel)
-        
+
         try:
             # Create PutLogRequest directly
             # Note: PutLogRequest structure depends on how it's defined in your .proto file
@@ -35,16 +32,16 @@ async def run_put_log(
                 log_type=pb2.LogType.LOG,
                 message=log_message,
             )
-            
+
             print(f"Sending log entry to {server_address}:")
             print(f"  Message: {log_message}")
-            
+
             # Call PutLog API
             response = await stub.PutLog(request)
-            
+
             # Display response
             print(f"PutLog response: {response}")
-            
+
         except grpc.RpcError as e:
             print(f"RPC error: {e.code()}: {e.details()}")
         except Exception as e:
@@ -56,9 +53,9 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python api_put_log.py 'log message' [LOG_LEVEL] [server_address]")
         sys.exit(1)
-    
+
     log_message = sys.argv[1]
     server_address = sys.argv[2] if len(sys.argv) > 2 else "127.0.0.1:8084"
-    
+
     # Run async function
     asyncio.run(run_put_log(log_message, server_address))


### PR DESCRIPTION
### Why
When client doesn't specify `timestamp`(int) parameter for gRPC `PutLog` API, it will be zero based on gRPC default spec.
Current code doesn't take care the case of zero.

### What
- When the incoming timestamp is zero, calculate timestamp in otaclient-iot-logging-server side.
- Add test scripts to test gRPC E2E feature.

### Tests
- verified the following matrix test cases

|  | otaclient v3.8.6 | otaclient with https://github.com/tier4/ota-client/pull/474 |
|:---|:---:|---:|
|iot-logger v1.2.0 | (HTTP) | HTTP |
|iot-logger with this PR | HTTP | gRPC(support both LOG and METRICS) |