### PR TITLE
ci: deprecate ubuntu20.04 pytest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,12 +27,10 @@ jobs:
       matrix:
         # currently we only need to ensure it is running on the following OS
         # with OS-shipped python interpreter.
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-22.04"]
         include:
           - os: ubuntu-22.04
             python_version: "3.10"
-          - os: ubuntu-20.04
-            python_version: "3.8"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout commit


### PR DESCRIPTION
### Why
Ubuntu 20.04 LTS runner is removed on Github.
https://github.com/actions/runner-images/issues/11101

### What
Remove Ubuntu 20.04 pytest