### PR TITLE
feat: support HTTP head command

### DIFF
--- a/src/otaclient_iot_logging_server/log_proxy_server.py
+++ b/src/otaclient_iot_logging_server/log_proxy_server.py
@@ -44,10 +44,12 @@ WAIT_BEFORE_SEND_READY_MSG = 2  # seconds
 
 async def _start_http_server(handler: OTAClientIoTLoggingServerServicer):
     app = web.Application()
-    app.add_routes([
-        web.head(r"/{ecu_id}", handler.http_head),
-        web.post(r"/{ecu_id}", handler.http_put_log),
-    ])
+    app.add_routes(
+        [
+            web.head(r"/{ecu_id}", handler.http_head),
+            web.post(r"/{ecu_id}", handler.http_put_log),
+        ]
+    )
 
     runner = web.AppRunner(app)
     await runner.setup()

--- a/src/otaclient_iot_logging_server/log_proxy_server.py
+++ b/src/otaclient_iot_logging_server/log_proxy_server.py
@@ -44,7 +44,10 @@ WAIT_BEFORE_SEND_READY_MSG = 2  # seconds
 
 async def _start_http_server(handler: OTAClientIoTLoggingServerServicer):
     app = web.Application()
-    app.add_routes([web.post(r"/{ecu_id}", handler.http_put_log)])
+    app.add_routes([
+        web.head(r"/{ecu_id}", handler.http_head),
+        web.post(r"/{ecu_id}", handler.http_put_log),
+    ])
 
     runner = web.AppRunner(app)
     await runner.setup()

--- a/src/otaclient_iot_logging_server/servicer.py
+++ b/src/otaclient_iot_logging_server/servicer.py
@@ -104,6 +104,15 @@ class OTAClientIoTLoggingServerServicer:
 
         return ErrorCode.NO_FAILURE
 
+    async def http_head(self, request: Request) -> PutLogResponse:
+        """
+        Handle HEAD requests for connectivity and availability checks.
+        """
+        _ecu_id = request.match_info["ecu_id"]
+        if self._allowed_ecus and _ecu_id not in self._allowed_ecus:
+            return web.Response(status=HTTPStatus.BAD_REQUEST)
+        return web.Response(status=HTTPStatus.OK)
+
     async def http_put_log(self, request: Request) -> PutLogResponse:
         """
         put log message from HTTP POST request.

--- a/tests/test_log_proxy_server.py
+++ b/tests/test_log_proxy_server.py
@@ -127,10 +127,12 @@ class TestLogProxyServer:
         aiohttp_server_logger = logging.getLogger("aiohttp")
         aiohttp_server_logger.setLevel("ERROR")
         # add handler to the server
-        app.add_routes([
-            web.head(r"/{ecu_id}", handler.http_head),
-            web.post(r"/{ecu_id}", handler.http_put_log),
-        ])
+        app.add_routes(
+            [
+                web.head(r"/{ecu_id}", handler.http_head),
+                web.post(r"/{ecu_id}", handler.http_put_log),
+            ]
+        )
         # star the server
         runner = web.AppRunner(app)
         try:


### PR DESCRIPTION
### Why
Currently, otaclient might not wait for iot-logger working.
The idea is that otaclient wait for iot-logger wake up by using(checking) HTTP head command.

### What
support HTTP head command for "`autoware's ip`/`ecu_id`" entpoints.