### PR TITLE
ci: always trigger test CI on main branches push/PR

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,11 @@ on:
   # allow the test CI to be manually triggerred
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
 jobs:
   pytest_with_coverage_on_supported_os:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,19 +4,11 @@ on:
   pull_request:
     branches:
       - main
-    # only trigger unit test CI when src or tests changed
-    paths:
-      - "src/**"
-      - "tests/**"
-      - ".github/workflows/test.yaml"
+
   push:
     branches:
       - main
-    # only trigger unit test CI when src or tests changed
-    paths:
-      - "src/**"
-      - "tests/**"
-      - ".github/workflows/test.yaml"
+
   # allow the test CI to be manually triggerred
   workflow_dispatch:
 


### PR DESCRIPTION
## Introduction

This PR updates test CI workflow file, now any pushes/PRs to main branch will trigger test CI. This is for later enabling CI status check before merging.