### PR TITLE
dep: update protobuf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "boto3>=1.34.35,<1.39",
   "botocore>=1.34.35,<1.35",
   "grpcio==1.70",
-  "protobuf>=4.21.12,<6.32",
+  "protobuf>=4.25.8,<6.32",
   "pydantic>=2.6,<3",
   "pydantic-settings>=2.2.1,<3",
   "pyyaml>=6.0.1,<7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ awsiot-credentialhelper>=0.6,<1.1
 boto3>=1.34.35,<1.39
 botocore>=1.34.35,<1.35
 grpcio==1.70
-protobuf>=4.21.12,<6.32
+protobuf>=4.25.8,<6.32
 pydantic>=2.6,<3
 pydantic-settings>=2.2.1,<3
 pyyaml>=6.0.1,<7

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34.35,<1.39" },
     { name = "botocore", specifier = ">=1.34.35,<1.35" },
     { name = "grpcio", specifier = "==1.70" },
-    { name = "protobuf", specifier = ">=4.21.12,<6.32" },
+    { name = "protobuf", specifier = ">=4.25.8,<6.32" },
     { name = "pydantic", specifier = ">=2.6,<3" },
     { name = "pydantic-settings", specifier = ">=2.2.1,<3" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },


### PR DESCRIPTION
### Why
https://tier4.atlassian.net/browse/RT4-17727
https://security.snyk.io/vuln/SNYK-PYTHON-PROTOBUF-10364902

Sync requests to update protobuf to 4.25.8 or higher.

### What
set minimum version as 4.25.8

### Test
Fixed version to 4.25.8 in test build, then verified the actual behavior in VM.
Confirmed that there is no breaking changes in Python between 4.21.12 and 4.25.8 in change log.