### PR TITLE
feat: remove log group creation

### DIFF
--- a/tests/test_aws_iot_logger.py
+++ b/tests/test_aws_iot_logger.py
@@ -146,9 +146,6 @@ class TestAWSIoTLogger:
 
     def test_thread_main(self, mocker: MockerFixture):
         func_to_test = AWSIoTLogger.thread_main
-        self._create_log_groups = mocked__create_log_groups = mocker.MagicMock(
-            spec=AWSIoTLogger._create_log_groups
-        )
 
         # ------ execution ------ #
         with pytest.raises(self._TestFinished):
@@ -156,6 +153,5 @@ class TestAWSIoTLogger:
         logger.info("execution finished")
 
         # ------ check result ------ #
-        mocked__create_log_groups.assert_called_once()
         # confirm the send_messages mock receives the expecting calls.
         assert self._merged_msgs == self._test_result


### PR DESCRIPTION
### Why
Currently, Log Group is created and managed in [this new IaC repo](https://github.com/tier4/otaclient-iot-logging-iac/tree/develop), we don't have to create the following log groups dynamically.
- `fms-dev-edge-otaclient`
- `fms-dev-edge-otaclient-metrics`

### What
Remove Log Group Creations