### PR TITLE
chore: revert boto3/botocore versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dynamic = [
 dependencies = [
   "aiohttp==3.10.11",
   "awsiot-credentialhelper>=0.6,<1.1",
-  "boto3>=1.34.35,<1.39",
-  "botocore>=1.34.35,<1.39",
+  "boto3>=1.34.35,<1.35",
+  "botocore>=1.34.35,<1.35",
   "grpcio==1.70",
   "protobuf>=4.25.8,<6.32",
   "pydantic>=2.6,<3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # DO NOT EDIT! Only for reference use.
 aiohttp==3.10.11
 awsiot-credentialhelper>=0.6,<1.1
-boto3>=1.34.35,<1.39
-botocore>=1.34.35,<1.39
+boto3>=1.34.35,<1.35
+botocore>=1.34.35,<1.35
 grpcio==1.70
 protobuf>=4.25.8,<6.32
 pydantic>=2.6,<3

--- a/uv.lock
+++ b/uv.lock
@@ -693,8 +693,8 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = "==3.10.11" },
     { name = "awsiot-credentialhelper", specifier = ">=0.6,<1.1" },
-    { name = "boto3", specifier = ">=1.34.35,<1.39" },
-    { name = "botocore", specifier = ">=1.34.35,<1.39" },
+    { name = "boto3", specifier = ">=1.34.35,<1.35" },
+    { name = "botocore", specifier = ">=1.34.35,<1.35" },
     { name = "grpcio", specifier = "==1.70" },
     { name = "protobuf", specifier = ">=4.25.8,<6.32" },
     { name = "pydantic", specifier = ">=2.6,<3" },


### PR DESCRIPTION
### Why
boto3/botocore dropped support for Python 3.8 starting from version 1.38.
In contrast, `requirements.txt` include version 1.38.
Currently, we specify these packages using a version range, so installation works without issues. However, if the lower bound of the supported versions changes in the future, installation in a Python 3.8 environment might fail.

### What
Revert the following PRs.
- https://github.com/tier4/otaclient-iot-logging-server/pull/48
- https://github.com/tier4/otaclient-iot-logging-server/pull/59