### PR TITLE
chore: update base image version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build_wheel:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Why
To create package, legacy image is still used.

### What
Changed to use the latest ubuntu image.