### PR TITLE
chore(deps): update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   // note that it is NOT the schedule of renovate task dispatching,
   //  but the time window of allowing renovate to create PRs,
   //  see https://docs.renovatebot.com/configuration-options/#schedule
-  "schedule": ["* 20-23,0-8 * * 1-5", "* * * * 0,6"],
+  "schedule": [ "* 20-23,0-8 * * 1-5", "* * * * 0,6" ],
   "lockFileMaintenance": {
     "enabled": true
   },
@@ -26,6 +26,10 @@
         "pep621"
       ],
       "rangeStrategy": "widen"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions updates"
     }
   ],
   "labels": [
@@ -35,6 +39,9 @@
     "labels": [
       "security",
       "dependencies"
+    ],
+    "gitIgnoredAuthors": [
+      "github-actions[bot]+sync-lockfile@users.noreply.github.com"
     ]
   },
   "prHourlyLimit": 16


### PR DESCRIPTION
## Introduction

This PR updates renovate config as follow:
1. add `gitIgnoredAuthors` config also under `vulnerabilityAlerts` section, as `vulnerabilityAlerts` will ignore all top-level configurations, need to specify the corresponding settings under `vulnerabilityAlerts` section to force apply the config.
2. group `github-actions` related update into a one PR.