### PR TITLE
chore: fix test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
 
       # export the coverage report to the comment!
       - name: Add coverage report to PR comment
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.os == 'ubuntu-24.04' && github.event_name == 'pull_request'
         uses: MishaKav/pytest-coverage-comment@ae0e8a539a3f310aefb3bfb6a2209778a21fa42b # v1.2.0
         with:
           pytest-xml-coverage-path: test_result/coverage.xml


### PR DESCRIPTION
### When
When a merge commit is pushed to main branch, test workflow is failed.
Because test workflow try to report the coverage as PR comment.

### What
report the coverage into comment only when the target even is PR.